### PR TITLE
ci: add basic GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "CI ready"


### PR DESCRIPTION
- PR 생성 시 기본적으로 실행되는 GitHub Actions 워크플로우 추가
- 현재는 단순히 "CI ready" 출력만 실행
- 이후 프로젝트 스택(Node/Python/Java)에 맞게 교체 예정
